### PR TITLE
Refactor: Extract check_submissions_open from decorator

### DIFF
--- a/cogs/checks.py
+++ b/cogs/checks.py
@@ -4,34 +4,37 @@ Custom checks for application commands
 import discord
 from discord import app_commands
 
+async def check_submissions_open(interaction: discord.Interaction) -> bool:
+    """
+    Reusable check to see if submissions are open.
+    Sends a message to the user if they are closed.
+    Returns True if open, False otherwise.
+    """
+    bot = interaction.client
+
+    if not hasattr(bot, 'db'):
+        await interaction.response.send_message(
+            "❌ A critical error occurred: Database not found.",
+            ephemeral=True
+        )
+        return False
+
+    are_open = await bot.db.are_submissions_open()
+    if not are_open:
+        await interaction.response.send_message(
+            "❌ Submissions are currently closed. Please try again later.",
+            ephemeral=True
+        )
+        return False
+    return True
+
+
 def submissions_open():
     """
-    Check if music submissions are currently open.
-    This is a decorator for app commands.
+    Decorator check to see if music submissions are currently open.
     """
     async def predicate(interaction: discord.Interaction) -> bool:
-        # The bot instance should be available through the interaction's client attribute
-        bot = interaction.client
-
-        # Check if the database is available
-        if not hasattr(bot, 'db'):
-            # This should not happen in normal operation
-            await interaction.response.send_message(
-                "❌ A critical error occurred: Database not found.",
-                ephemeral=True
-            )
-            return False
-
-        # Check the submission status
-        are_open = await bot.db.are_submissions_open()
-        if not are_open:
-            await interaction.response.send_message(
-                "❌ Submissions are currently closed. Please try again later.",
-                ephemeral=True
-            )
-            return False
-
-        return True
+        return await check_submissions_open(interaction)
 
     return app_commands.check(predicate)
 


### PR DESCRIPTION
- Extracted the submission status check logic from the `submissions_open` decorator into a new, standalone `async` function named `check_submissions_open`.
- This resolves an `ImportError` in `submission_cog.py` where the function was being imported but did not exist as a standalone function.
- The `submissions_open` decorator now calls the new `check_submissions_open` function, ensuring that the logic is centralized and reusable.