### PR TITLE
feat: Add Calls Played channel and bookmark button

### DIFF
--- a/database.py
+++ b/database.py
@@ -316,6 +316,19 @@ class Database:
                 row = await cursor.fetchone()
                 return dict(row) if row else None
 
+    async def set_calls_played_channel(self, channel_id: int):
+        """Set the channel for 'Calls Played' announcements."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("INSERT OR REPLACE INTO bot_settings (key, value) VALUES ('calls_played_channel', ?)", (str(channel_id),))
+            await db.commit()
+
+    async def get_calls_played_channel(self) -> Optional[int]:
+        """Get the channel ID for 'Calls Played' announcements."""
+        async with aiosqlite.connect(self.db_path) as db:
+            async with db.execute("SELECT value FROM bot_settings WHERE key = 'calls_played_channel'") as cursor:
+                row = await cursor.fetchone()
+                return int(row[0]) if row else None
+
     async def close(self):
         """Close database connection"""
         pass


### PR DESCRIPTION
This commit introduces two new features requested by the user:

1.  **Configurable 'Calls Played' Channel:**
    - A new slash command `/setcallsplayedchannel` is added for administrators to designate a specific text channel for 'Calls Played' announcements.
    - When the `/next` command is used, an embed with the submission details is now automatically sent to this configured channel, in addition to being shown in the ephemeral response.
    - The channel setting is stored in the `bot_settings` table in the database.

2.  **Bookmark Button on `/next` Command:**
    - The ephemeral response from the `/next` command now includes a "Bookmark" button.
    - Clicking this button bookmarks the submission, sending its details to the configured bookmark channel.
    - This provides a more streamlined workflow for admins compared to using the separate `/bookmark <id>` command.
    - The button uses `discord.ui.View` for modern component interaction.