### PR TITLE
feat: Implement comprehensive queue system overhaul

### DIFF
--- a/cogs/checks.py
+++ b/cogs/checks.py
@@ -4,40 +4,6 @@ Custom checks for application commands
 import discord
 from discord import app_commands
 
-async def check_submissions_open(interaction: discord.Interaction) -> bool:
-    """
-    Reusable check to see if submissions are open.
-    Sends a message to the user if they are closed.
-    Returns True if open, False otherwise.
-    """
-    bot = interaction.client
-
-    if not hasattr(bot, 'db'):
-        await interaction.response.send_message(
-            "❌ A critical error occurred: Database not found.",
-            ephemeral=True
-        )
-        return False
-
-    are_open = await bot.db.are_submissions_open()
-    if not are_open:
-        await interaction.response.send_message(
-            "❌ Submissions are currently closed. Please try again later.",
-            ephemeral=True
-        )
-        return False
-    return True
-
-
-def submissions_open():
-    """
-    Decorator check to see if music submissions are currently open.
-    """
-    async def predicate(interaction: discord.Interaction) -> bool:
-        return await check_submissions_open(interaction)
-
-    return app_commands.check(predicate)
-
 def is_admin():
     """
     Check if the user has admin permissions (manage_guild).

--- a/cogs/queue_view.py
+++ b/cogs/queue_view.py
@@ -13,7 +13,7 @@ class PaginatedQueueView(discord.ui.View):
     """Discord View for paginated queue display with navigation buttons"""
     
     def __init__(self, bot, queue_line: str, entries_per_page: int = 10):
-        super().__init__(timeout=900)  # 15 minutes timeout
+        super().__init__(timeout=None)  # Never timeout
         self.bot = bot
         self.queue_line = queue_line
         self.entries_per_page = entries_per_page
@@ -69,7 +69,7 @@ class PaginatedQueueView(discord.ui.View):
                         pass # Keep timestamp_str empty if parsing fails
 
                 description_lines.append(
-                    f"**{i}.** `#{sub['id']}`: **{sub['artist_name']} – {sub['song_name']}** "
+                    f"**{i}.** `#{sub['public_id']}`: **{sub['artist_name']} – {sub['song_name']}** "
                     f"by *{sub['username']}*{timestamp_str}{link_text}"
                 )
             embed.description = "\n".join(description_lines)


### PR DESCRIPTION
This commit introduces a wide range of features and improvements to the music queue bot:

- **Persistent Pagination:** Queue pagination menus no longer time out.
- **Randomized IDs:** Submissions are now assigned a unique, random 6-digit public ID.
- **Skip Submission Flow:** A new 'Pending Skips' queue is added. Users are prompted to choose whether their submission is a 'Skip' or for the 'Free' line.
- **Selective Queue Closing:** Admins can now close submissions only for the 'Free' line, while 'Skip' submissions remain open.
- **Now Playing Channel:**
    - A new `/setnowplayingchannel` command allows admins to designate a channel for announcements.
    - The `/next` command now posts a formatted message to this channel, tagging the submitter.
- **Queue Behavior:**
    - Moved submissions are now placed at the bottom of the target queue.
    - The `/myqueue` command has been simplified to show only the track name and public ID.
- **Database:** The schema has been updated to support these new features, including migrating existing data.
- **Code Refinements:** Replaced outdated checks and updated command handling to use the new `public_id` system.