### PR TITLE
fix: Handle user mentions correctly in /next command

### DIFF
--- a/cogs/admin_cog.py
+++ b/cogs/admin_cog.py
@@ -220,8 +220,9 @@ class AdminCog(commands.Cog):
             if now_playing_channel_id:
                 channel = self.bot.get_channel(now_playing_channel_id)
                 if channel:
-                    user = self.bot.get_user(next_sub['user_id']) or f"<@{next_sub['user_id']}>"
-                    announcement = f"🎶 Now Playing: {next_sub['artist_name']} – {next_sub['song_name']} (submitted by {user.mention})"
+                    user = self.bot.get_user(next_sub['user_id'])
+                    mention = user.mention if user else f"<@{next_sub['user_id']}>"
+                    announcement = f"🎶 Now Playing: {next_sub['artist_name']} – {next_sub['song_name']} (submitted by {mention})"
                     await channel.send(announcement)
 
             embed = discord.Embed(


### PR DESCRIPTION
This commit fixes a bug in the `/next` command that caused an `AttributeError` when announcing a track from a user not present in the bot's cache.

The logic has been updated to:
1. Attempt to fetch the `user` object from the bot's cache.
2. If the user object is found, use `user.mention`.
3. If the user is not found (is `None`), construct the mention manually (e.g., `<@user_id>`) to ensure the announcement is always successful.