### PR TITLE
feat: Implement robust, self-healing queue views and update skip lines

### DIFF
--- a/cogs/queue_cog.py
+++ b/cogs/queue_cog.py
@@ -98,9 +98,11 @@ class QueueCog(commands.Cog):
     def _get_line_color(self, queue_line: str) -> discord.Color:
         """Get color for queue line embed"""
         colors = {
-            QueueLine.BACKTOBACK.value: discord.Color.red(),
-            QueueLine.DOUBLESKIP.value: discord.Color.orange(),
-            QueueLine.SKIP.value: discord.Color.yellow(),
+            QueueLine.TWENTYFIVEPLUSSKIP.value: discord.Color.red(),
+            QueueLine.TWENTYSKIP.value: discord.Color.dark_orange(),
+            QueueLine.FIFTEENSKIP.value: discord.Color.orange(),
+            QueueLine.TENSKIP.value: discord.Color.gold(),
+            QueueLine.FIVESKIP.value: discord.Color.yellow(),
             QueueLine.FREE.value: discord.Color.green(),
             QueueLine.CALLS_PLAYED.value: discord.Color.purple()
         }
@@ -131,9 +133,11 @@ class QueueCog(commands.Cog):
         embed.add_field(
             name="🎯 Queue Lines (Priority Order)",
             value=(
-                "**BackToBack** - Highest priority\n"
-                "**DoubleSkip** - High priority\n"
-                "**Skip** - Medium priority\n"
+                "**25+ Skip** - Highest priority\n"
+                "**20 Skip** - Very high priority\n"
+                "**15 Skip** - High priority\n"
+                "**10 Skip** - Medium-high priority\n"
+                "**5 Skip** - Medium priority\n"
                 "**Free** - Standard submissions (1 per user)\n"
                 "**Calls Played** - Archive of reviewed tracks"
             ),

--- a/database.py
+++ b/database.py
@@ -370,6 +370,23 @@ class Database:
                         return None
         return None
 
+    async def get_all_bot_settings(self) -> Dict[str, Any]:
+        """Get all settings from the bot_settings table."""
+        settings = {}
+        async with aiosqlite.connect(self.db_path) as db:
+            async with db.execute("SELECT key, value FROM bot_settings") as cursor:
+                async for row in cursor:
+                    key, value = row
+                    # Try to convert to int if possible, otherwise keep as string
+                    if value is not None:
+                        try:
+                            settings[key] = int(value)
+                        except (ValueError, TypeError):
+                            settings[key] = value
+                    else:
+                        settings[key] = None
+        return settings
+
     async def close(self):
         """Close database connection"""
         pass


### PR DESCRIPTION
This commit delivers a comprehensive update to the queue system, focusing on three key areas: updating the skip line options, ensuring view persistence across bot restarts, and implementing robust channel management.

Key changes:
- **Skip Line Update:** Replaces the old skip lines with a new tiered system (`5 Skip` to `25+ Skip`) and updates the submission priority order accordingly.
- **Persistent Views:** Implements a self-healing system that runs on bot startup. It scans all configured queue channels, cleans up old or duplicate views, and ensures a single, active, pinned view is always present with working buttons.
- **Settings Cache:** Introduces a bot-wide settings cache that is loaded on startup to manage channel IDs for bookmarks and now-playing announcements. This fixes persistence issues by ensuring a consistent state.
- **Aggressive Cleanup:** Adds a channel cleanup routine that purges all non-essential messages from queue channels, keeping them clean. This feature includes a robust exemption system to protect channels like 'Calls Played', 'Now Playing', and 'Bookmarks'.
- **Command Fix:** Corrects the `/setline` and `/move` commands to display user-friendly names for the new queue lines, making them fully configurable.