### PR TITLE
feat: Enhance submission user experience

### DIFF
--- a/cogs/submission_cog.py
+++ b/cogs/submission_cog.py
@@ -61,14 +61,19 @@ class SkipConfirmationView(discord.ui.View):
             )
 
             embed = discord.Embed(
-                title="✅ Submission Added!",
-                description=f"Your music has been added to the **{line_name}** line.",
+                title="✅ Submission Successful!",
+                description=f"Your track has been added to the **{line_name}** line.",
                 color=discord.Color.green()
             )
             embed.add_field(name="Artist", value=self.submission_data['artist_name'], inline=True)
             embed.add_field(name="Song", value=self.submission_data['song_name'], inline=True)
             embed.add_field(name="Submission ID", value=f"#{public_id}", inline=False)
-            embed.set_footer(text="Use /myqueue to see your submissions | Luxurious Radio By Emerald Beats")
+            embed.add_field(
+                name="Check Your Queue",
+                value="To view the status of all your submissions, use the `/myqueue` command.",
+                inline=False
+            )
+            embed.set_footer(text="Luxurious Radio By Emerald Beats")
 
             await interaction.response.send_message(embed=embed, ephemeral=True)
 
@@ -156,8 +161,13 @@ class SubmissionModal(discord.ui.Modal, title='Submit Music for Review'):
             'note': str(self.note.value).strip() if self.note.value else None
         }
 
+        clarification_message = (
+            "Is this a **Skip** submission?\n\n"
+            "Choosing 'Yes' means your song will not be played unless you also send a skip. "
+            "See the `#skip-the-line-info` channel for more details."
+        )
         view = SkipConfirmationView(self.bot, submission_data)
-        await interaction.response.send_message("Is this a **Skip** submission?", view=view, ephemeral=True)
+        await interaction.response.send_message(clarification_message, view=view, ephemeral=True)
         view.message = await interaction.original_response()
 
 
@@ -243,29 +253,83 @@ class SubmissionCog(commands.Cog):
             'note': note.strip() if note else None
         }
 
+        clarification_message = (
+            "Is this a **Skip** submission?\n\n"
+            "Choosing 'Yes' means your song will not be played unless you also send a skip. "
+            "See the `#skip-the-line-info` channel for more details."
+        )
         view = SkipConfirmationView(self.bot, submission_data)
-        await interaction.response.send_message("Is this a **Skip** submission?", view=view, ephemeral=True)
+        await interaction.response.send_message(clarification_message, view=view, ephemeral=True)
         view.message = await interaction.original_response()
 
 
-    @app_commands.command(name="myqueue", description="View your submissions in all queues")
+    @app_commands.command(name="myqueue", description="View your submissions from the last 48 hours")
     async def my_queue(self, interaction: discord.Interaction):
-        """Show user's submissions across all lines"""
-        submissions = await self.bot.db.get_user_submissions(interaction.user.id)
+        """Shows the user's submissions from the last 48 hours, categorized."""
+        from datetime import datetime, timedelta
+
+        # Calculate the timestamp for 48 hours ago
+        since_time = datetime.utcnow() - timedelta(hours=48)
+        since_iso = since_time.isoformat()
+
+        # Fetch recent submissions
+        submissions = await self.bot.db.get_user_submissions_since(interaction.user.id, since_iso)
 
         if not submissions:
-            embed = discord.Embed(title="Your Queue", description="You don't have any active submissions.", color=discord.Color.blue())
+            embed = discord.Embed(
+                title="Your Recent Submissions",
+                description="You haven't made any submissions in the last 48 hours.",
+                color=discord.Color.blue()
+            )
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
-        embed = discord.Embed(title="Your Queue Submissions", color=discord.Color.blue())
+        # Separate submissions into categories
+        played_tracks = []
+        in_queue_tracks = []
 
-        description_lines = []
         for sub in submissions:
-            description_lines.append(f"**{sub['artist_name']} – {sub['song_name']}** `(ID: #{sub['public_id']})`")
+            track_info = f"• **{sub['artist_name']} – {sub['song_name']}** `(ID: #{sub['public_id']})`"
+            if sub['queue_line'] == QueueLine.CALLS_PLAYED.value:
+                played_tracks.append(track_info)
+            else:
+                in_queue_tracks.append(track_info)
 
-        embed.description = "\n".join(description_lines) if description_lines else "You have no submissions."
+        # Create the embed
+        embed = discord.Embed(
+            title=f"Submissions by {interaction.user.display_name}",
+            description="Here are your tracks from the last 48 hours.",
+            color=discord.Color.purple()
+        )
+        embed.set_thumbnail(url=interaction.user.display_avatar.url)
 
+        if in_queue_tracks:
+            embed.add_field(
+                name="⏳ In Queue",
+                value="\n".join(in_queue_tracks),
+                inline=False
+            )
+        else:
+            embed.add_field(
+                name="⏳ In Queue",
+                value="No tracks currently in the queue.",
+                inline=False
+            )
+
+        if played_tracks:
+            embed.add_field(
+                name="✅ Played Tracks",
+                value="\n".join(played_tracks),
+                inline=False
+            )
+        else:
+            embed.add_field(
+                name="✅ Played Tracks",
+                value="No tracks have been played recently.",
+                inline=False
+            )
+
+        embed.set_footer(text="Showing submissions from the last 48 hours.")
         await interaction.response.send_message(embed=embed, ephemeral=True)
 
 

--- a/database.py
+++ b/database.py
@@ -124,6 +124,19 @@ class Database:
                 rows = await cursor.fetchall()
                 return [dict(row) for row in rows]
 
+    async def get_user_submissions_since(self, user_id: int, since: str) -> List[Dict[str, Any]]:
+        """Get all submissions for a specific user since a given datetime."""
+        query = """
+            SELECT * FROM submissions
+            WHERE user_id = ? AND submission_time >= ?
+            ORDER BY submission_time DESC
+        """
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute(query, (user_id, since)) as cursor:
+                rows = await cursor.fetchall()
+                return [dict(row) for row in rows]
+
     async def get_queue_submissions(self, queue_line: str) -> List[Dict[str, Any]]:
         """
         Get all submissions for a specific queue line.


### PR DESCRIPTION
This commit introduces several improvements to the user submission workflow:

- The `/myqueue` command is refactored to display a user's submissions from the last 48 hours, categorized into "Played" and "In Queue" tracks.
- The submission confirmation message is updated to be more explicit, confirming success and instructing the user to use the `/myqueue` command.
- The "Is this a Skip submission?" prompt is clarified to explain what a skip entails and directs users to the `#skip-the-line-info` channel for more details.