### PR TITLE
feat: Add admin commands, enhance submission flow, and add diagnostics

### DIFF
--- a/cogs/admin_cog.py
+++ b/cogs/admin_cog.py
@@ -475,6 +475,29 @@ class AdminCog(commands.Cog):
         except Exception as e:
             await interaction.followup.send(f"❌ An error occurred while fetching settings: {e}", ephemeral=True)
 
+    @app_commands.command(name="cleanqueues", description="[ADMIN] Remove old, unused queue line settings from the database.")
+    @is_admin()
+    async def clean_queues(self, interaction: discord.Interaction):
+        """Removes stale queue line settings that are no longer part of the bot's valid queues."""
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            removed_count = await self.bot.db.clear_stale_queue_lines()
+            if removed_count > 0:
+                embed = discord.Embed(
+                    title="✅ Stale Queues Cleaned",
+                    description=f"Successfully removed {removed_count} old queue line setting(s) from the database.",
+                    color=discord.Color.green()
+                )
+            else:
+                embed = discord.Embed(
+                    title="👍 No Stale Queues Found",
+                    description="Your queue line settings are all up-to-date. No cleanup was needed.",
+                    color=discord.Color.blue()
+                )
+            await interaction.followup.send(embed=embed, ephemeral=True)
+        except Exception as e:
+            await interaction.followup.send(f"❌ An error occurred during cleanup: {e}", ephemeral=True)
+
 
 async def setup(bot):
     """Setup function for the cog"""


### PR DESCRIPTION
This comprehensive commit introduces several new features, fixes, and enhancements based on user feedback.

New Features:
- Adds an admin-only slash command, `/selfheal`, to manually trigger the self-healing and channel cleanup routine.
- Adds an admin-only slash command, `/showsettings`, to display all configured channel IDs for queues and other settings, serving as a diagnostic tool.
- Adds a safe, admin-only slash command, `/cleanqueues`, to manually remove old, unused queue line settings from the database.
- Enhances the submission process by adding an optional 'TikTok Username' field to both the `/submit` and `/submitfile` commands. This information is now stored and displayed in admin-facing embeds.
- Implements a user-friendly reminder for cloud storage links, prompting users to ensure their links are publicly accessible.

Fixes & Diagnostics:
- Reverts a faulty implementation of automatic stale queue cleanup that was incorrectly deleting active settings on reboot. The new `/cleanqueues` command provides a safer, manual alternative.
- Adds detailed diagnostic logging to the `set_bookmark_channel` function to help debug an issue where the setting was not being saved correctly.

This commit also confirms that previously requested features (`/mysubmissions` rename and Apple Music link rejection) were already implemented in the codebase.