### PR TITLE
feat: Add admin commands, enhance submissions, and add diagnostics

### DIFF
--- a/cogs/admin_cog.py
+++ b/cogs/admin_cog.py
@@ -319,18 +319,35 @@ class AdminCog(commands.Cog):
     @app_commands.describe(channel="The text channel to use for bookmarks")
     @is_admin()
     async def set_bookmark_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
-        """Set the channel for bookmarked submissions"""
+        """Set the channel for bookmarked submissions with detailed feedback."""
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
         try:
+            # Step 1: Call the database function
+            await interaction.followup.send("⚙️ Accessing the database...", ephemeral=True)
             await self.bot.db.set_bookmark_channel(channel.id)
+
+            # Step 2: Update the local cache
+            await interaction.followup.send("📝 Updating live settings cache...", ephemeral=True)
             self.bot.settings_cache['bookmark_channel_id'] = channel.id
+
+            # Step 3: Final confirmation
             embed = discord.Embed(
-                title="✅ Bookmark Channel Set",
-                description=f"Bookmark channel is now set to {channel.mention}",
+                title="✅ Bookmark Channel Set Successfully",
+                description=f"The bookmark channel has been set to {channel.mention}.",
                 color=discord.Color.green()
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
+            await interaction.followup.send(embed=embed, ephemeral=True)
+
         except Exception as e:
-            await interaction.response.send_message(f"❌ Error setting bookmark channel: {str(e)}", ephemeral=True)
+            # Send a detailed error message if anything fails
+            error_embed = discord.Embed(
+                title="❌ An Error Occurred",
+                description="Failed to set the bookmark channel. Here's the error information:",
+                color=discord.Color.red()
+            )
+            error_embed.add_field(name="Error Details", value=f"```\n{e}\n```", inline=False)
+            await interaction.followup.send(embed=error_embed, ephemeral=True)
 
     @app_commands.command(name="setnowplayingchannel", description="Set the channel for 'Now Playing' announcements")
     @app_commands.describe(channel="The text channel to use for announcements")

--- a/database.py
+++ b/database.py
@@ -370,17 +370,10 @@ class Database:
                 return dict(row) if row else None
 
     async def set_bookmark_channel(self, channel_id: int):
-        """Set the bookmark channel."""
-        print(f"DATABASE: Attempting to set bookmark channel to ID: {channel_id}")
-        try:
-            async with aiosqlite.connect(self.db_path) as db:
-                print("DATABASE: Connection successful.")
-                await db.execute("INSERT OR REPLACE INTO bot_settings (key, value) VALUES ('bookmark_channel_id', ?)", (str(channel_id),))
-                print(f"DATABASE: Executed INSERT OR REPLACE for bookmark_channel_id with value {channel_id}.")
-                await db.commit()
-                print("DATABASE: Commit successful for set_bookmark_channel.")
-        except Exception as e:
-            print(f"DATABASE: ERROR in set_bookmark_channel: {e}")
+        """Set the bookmark channel. Raises an exception on failure."""
+        async with aiosqlite.connect(self.db_path) as db:
+            await db.execute("INSERT OR REPLACE INTO bot_settings (key, value) VALUES ('bookmark_channel_id', ?)", (str(channel_id),))
+            await db.commit()
 
     async def get_bookmark_channel(self) -> Optional[int]:
         """Get the bookmark channel ID"""


### PR DESCRIPTION
This comprehensive commit introduces several new features, fixes, and enhancements based on user feedback and interactive debugging.

New Features & Commands:
- Adds an admin-only slash command, `/selfheal`, to manually trigger the self-healing and channel cleanup routine for all queue channels.
- Adds an admin-only slash command, `/showsettings`, to display all configured channel IDs for queues and other settings, serving as a diagnostic tool.
- Adds a safe, admin-only slash command, `/cleanqueues`, to manually remove old, unused queue line settings from the database, replacing a faulty automatic cleanup.
- Enhances the submission process by adding an optional 'TikTok Username' field to both the `/submit` and `/submitfile` commands. This information is now stored and displayed in admin-facing embeds.
- Implements a user-friendly reminder for cloud storage links, prompting users to ensure their links are publicly accessible.

Fixes & Diagnostics:
- Implements a new in-Discord diagnostic system for the `/setbookmarkchannel` command. It now provides step-by-step ephemeral feedback directly to the user, making it possible to debug settings issues without access to console logs. This replaces a previous implementation that relied on `print` statements.

This commit also confirms that previously requested features (`/mysubmissions` rename and Apple Music link rejection) were already correctly implemented in the codebase.