### PR TITLE
feat: Add admin commands, enhance submissions, and add diagnostics

### DIFF
--- a/database.py
+++ b/database.py
@@ -387,6 +387,14 @@ class Database:
                         return None
         return None
 
+    async def get_all_channel_settings(self) -> List[Dict[str, Any]]:
+        """Get all configured queue line channels."""
+        async with aiosqlite.connect(self.db_path) as db:
+            db.row_factory = aiosqlite.Row
+            async with db.execute("SELECT * FROM channel_settings ORDER BY queue_line") as cursor:
+                rows = await cursor.fetchall()
+                return [dict(row) for row in rows]
+
     async def get_all_bot_settings(self) -> Dict[str, Any]:
         """Get all settings from the bot_settings table."""
         settings = {}


### PR DESCRIPTION
This comprehensive commit introduces several new features, fixes, and enhancements based on user feedback and interactive debugging.

New Features & Commands:
- Adds an admin-only slash command, `/selfheal`, to manually trigger the self-healing and channel cleanup routine.
- Adds an admin-only slash command, `/showsettings`, to display all configured channel IDs for queues and other settings, serving as a diagnostic tool.
- Adds a safe, admin-only slash command, `/cleanqueues`, to manually remove old, unused queue line settings from the database.
- Enhances the submission process by adding an optional 'TikTok Username' field to both the `/submit` and `/submitfile` commands. This information is now stored and displayed in admin-facing embeds.
- Implements a user-friendly reminder for cloud storage links, prompting users to ensure their links are publicly accessible.

Fixes & Diagnostics:
- Restores the `get_all_channel_settings` function in `database.py`, which was accidentally removed and caused an error in the `/showsettings` command.
- Implements a new in-Discord diagnostic system for the `/setbookmarkchannel` command. It now provides step-by-step ephemeral feedback directly to the user, making it possible to debug settings issues without access to console logs.

This commit also confirms that previously requested features (`/mysubmissions` rename and Apple Music link rejection) were already correctly implemented in the codebase.