### PR TITLE
feat: Add definitive database test and enhance diagnostics

### DIFF
--- a/database.py
+++ b/database.py
@@ -412,6 +412,32 @@ class Database:
                         settings[key] = None
         return settings
 
+    async def write_and_verify_setting(self, key: str, value: str) -> bool:
+        """
+        Writes a setting to the database and then immediately reads it back
+        in a separate connection to verify persistence.
+        Returns True if the write was successful and verified, False otherwise.
+        """
+        try:
+            # Step 1: Write the value
+            async with aiosqlite.connect(self.db_path) as db:
+                await db.execute("INSERT OR REPLACE INTO bot_settings (key, value) VALUES (?, ?)", (key, value))
+                await db.commit()
+
+            # Step 2: Read the value back in a new connection
+            async with aiosqlite.connect(self.db_path) as db:
+                async with db.execute("SELECT value FROM bot_settings WHERE key = ?", (key,)) as cursor:
+                    row = await cursor.fetchone()
+                    if row and row[0] == value:
+                        return True
+                    else:
+                        # This case means the value was not written or read back correctly
+                        return False
+        except Exception as e:
+            # This case means an error occurred during the process
+            print(f"DATABASE: An exception occurred during write/verify: {e}")
+            return False
+
     async def close(self):
         """Close database connection"""
         pass


### PR DESCRIPTION
This commit introduces a critical diagnostic tool to resolve a persistent database saving issue, alongside other enhancements and fixes.

Core Fix & Diagnostics:
- Adds a new admin-only command, `/testdatabase`, which performs a definitive write-and-read-back test on the database. This command will confirm whether changes are being saved to the `music_queue.db` file, helping to diagnose potential file permission issues.
- Implements the corresponding `write_and_verify_setting` function in `database.py` to support this test.
- Enhances the `/setline` command with step-by-step in-Discord feedback, matching the diagnostics previously added to `/setbookmarkchannel`, to help isolate failures in settings commands.

Other Features & Fixes:
- Includes the previously developed admin commands: `/selfheal`, `/showsettings`, and `/cleanqueues`.
- Includes the submission flow enhancements: the 'TikTok Username' field and the cloud storage link reminder.
- Fixes a bug where the `get_all_channel_settings` function was accidentally removed, causing an error in `/showsettings`.

This commit consolidates all work done to address the user's initial requests and the subsequent, critical database persistence problems.