### PR TITLE
fix: Prevent command timeout by deferring response before import

### DIFF
--- a/cogs/tiktok_cog.py
+++ b/cogs/tiktok_cog.py
@@ -43,11 +43,11 @@ class TikTokCog(commands.Cog):
     @app_commands.describe(unique_id="The @unique_id of the TikTok user to connect to.")
     async def connect(self, interaction: discord.Interaction, unique_id: str):
         """Connects the bot to a specified TikTok Live stream."""
+        await interaction.response.defer(ephemeral=True, thinking=True)
+
         # Defer the import until the command is actually used
         from TikTokLive import TikTokLiveClient
         from TikTokLive.types.events import ConnectEvent, DisconnectEvent
-
-        await interaction.response.defer(ephemeral=True, thinking=True)
 
         if self.is_connected:
             await interaction.followup.send("Already connected to a TikTok LIVE. Please disconnect first.", ephemeral=True)


### PR DESCRIPTION
This commit resolves an "application did not respond" error that occurred when using the `/tiktok connect` command.

The root cause was that the deferred import of the `TikTokLive` library was taking too long, causing the interaction to time out before the bot could acknowledge it with Discord.

The fix is to move the `interaction.response.defer()` call to be the very first line in the `connect` command's execution. This ensures that Discord receives an immediate acknowledgement, preventing the timeout and allowing the slower import and connection logic to proceed safely.