### PR TITLE
Fix(cogs): Remove guild_only decorator from TikTokCog

### DIFF
--- a/cogs/tiktok_cog.py
+++ b/cogs/tiktok_cog.py
@@ -25,7 +25,6 @@ INTERACTION_POINTS = {
     "like": 1,
 }
 
-@app_commands.guild_only()
 @app_commands.default_permissions(administrator=True)
 class TikTokCog(commands.GroupCog, name="tiktok", description="Commands for managing TikTok Live integration."):
     """Handles TikTok Live integration and engagement rewards."""


### PR DESCRIPTION
The `/tiktok` commands were still not visible after the initial refactor to GroupCog. This was likely caused by the `@app_commands.guild_only()` decorator conflicting with the bot's command syncing strategy.

By removing the `guild_only` decorator, the commands are now registered globally, which should resolve the visibility issue and make them available in all guilds the bot is a member of. The commands remain protected by the `@app_commands.default_permissions(administrator=True)` decorator.