### PR TITLE
Fix(config): Add dependency installation to Replit startup

### DIFF
--- a/.replit
+++ b/.replit
@@ -23,6 +23,10 @@ author = "agent"
 
 [[workflows.workflow.tasks]]
 task = "shell.exec"
+args = "pip install -r requirements.txt"
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
 args = "python main.py"
 
 [workflows.workflow.metadata]


### PR DESCRIPTION
The root cause of the TikTok commands not appearing was that the `TikTokLive` dependency was not installed in the environment. This was because the Replit startup command in the `.replit` file only ran `python main.py` without first installing the required packages.

This change modifies the `.replit` file to execute `pip install -r requirements.txt` before the main application is started. This ensures that all necessary dependencies are always present, making the application deployment robust and fixing the cog loading issue.