### PR TITLE
Fix(deploy): Add Procfile for platform-agnostic startup

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: pip install -r requirements.txt && python main.py


### PR DESCRIPTION
The bot was failing to start on Railway because the platform was not installing the necessary dependencies from `requirements.txt` before running the application. The previous fix was specific to Replit and did not apply to other hosting environments.

This commit adds a `Procfile`, which is a standard way to declare process types and startup commands for many hosting platforms, including Railway. The `worker` process is defined to first install all dependencies using `pip` and then run the main bot script.

This ensures that the application environment is always correctly configured on deployment, resolving the startup crash caused by missing dependencies.