### PR TITLE
Fix(startup): Prevent blocking on_ready with background task

### DIFF
--- a/main.py
+++ b/main.py
@@ -108,10 +108,10 @@ class MusicQueueBot(commands.Bot):
             # Register persistent views
             self.add_view(PaginatedQueueView(self, queue_line="dummy")) # Pass dummy args
 
-            # Initialize all queue displays
+            # Initialize all queue displays in a background task to not block startup
             queue_view_cog = self.get_cog('QueueViewCog')
             if queue_view_cog:
-                await queue_view_cog.initialize_all_views()
+                asyncio.create_task(queue_view_cog.initialize_all_views())
 
             self.initial_startup = False
 


### PR DESCRIPTION
The bot was experiencing a significant startup delay because the `initialize_all_views()` function was being awaited directly in the `on_ready` event. This function performs heavy, time-consuming operations, such as fetching all pinned messages and purging channels, which blocked the bot from becoming responsive until all views were initialized.

This commit resolves the issue by wrapping the `initialize_all_views()` call in `asyncio.create_task()`. This runs the view initialization process as a non-blocking background task, allowing the `on_ready` event to complete immediately and the bot to come online promptly.