### PR TITLE
Diag: Add tracing statements to startup sequence

### DIFF
--- a/cogs/tiktok_cog.py
+++ b/cogs/tiktok_cog.py
@@ -30,6 +30,7 @@ class TikTokCog(commands.GroupCog, name="tiktok", description="Commands for mana
     """Handles TikTok Live integration and engagement rewards."""
 
     def __init__(self, bot: commands.Bot):
+        print("--- TRACE: TikTokCog __init__ called ---")
         self.bot: commands.Bot = bot
         logging.info("--- TikTokCog IS BEING INITIALIZED ---")
         self.bot.tiktok_client: Optional[TikTokLiveClient] = None

--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ class MusicQueueBot(commands.Bot):
         await self.db.initialize()
 
         # Load cogs
+        print("--- TRACE: Starting to load cogs ---")
         # Load cogs one by one for better error tracking
         cogs_to_load = [
             'cogs.queue_view',
@@ -70,8 +71,10 @@ class MusicQueueBot(commands.Bot):
                 logging.info(f"Successfully loaded cog: {cog}")
             except Exception as e:
                 logging.error(f"Failed to load cog {cog}: {e}", exc_info=True)
+                print(f"!!! FAILED TO LOAD COG {cog}: {e} !!!")
 
         # Sync slash commands
+        print("--- TRACE: Cogs loaded, starting command sync ---")
         try:
             guild_id = os.getenv('GUILD_ID')
             if guild_id:
@@ -86,6 +89,7 @@ class MusicQueueBot(commands.Bot):
                 logging.info(f"Synced {len(synced)} command(s) globally")
         except Exception as e:
             logging.error(f"Failed to sync commands: {e}")
+            print(f"!!! FAILED TO SYNC COMMANDS: {e} !!!")
 
     async def on_ready(self):
         """Called when bot is ready"""


### PR DESCRIPTION
To diagnose a silent failure where the `/tiktok` commands are not appearing, this commit adds several `print()` statements to the startup process.

These statements will trace the execution flow of:
- Cog loading in `main.py`
- `TikTokCog` initialization in `cogs/tiktok_cog.py`
- Command tree syncing in `main.py`

This is intended to be a temporary diagnostic step to expose the point of failure in the Railway deployment logs.