### PR TITLE
Fix(cogs): Correct TikTokLive error import path

### DIFF
--- a/cogs/tiktok_cog.py
+++ b/cogs/tiktok_cog.py
@@ -6,7 +6,7 @@ from discord import app_commands
 from typing import Optional, Dict, Any
 from TikTokLive import TikTokLiveClient
 from TikTokLive.events import CommentEvent, ConnectEvent, DisconnectEvent, GiftEvent, LikeEvent, ShareEvent
-from TikTokLive.errors import UserNotFoundError, LiveNotFoundError
+from TikTokLive.client.errors import UserNotFoundError, LiveNotFoundError
 
 # --- Constants ---
 # Map gift coin values to the queue they unlock.


### PR DESCRIPTION
The cog was still failing to load due to a `ModuleNotFoundError: No module named 'TikTokLive.errors'`. The previous fix for the event imports was correct, but the error classes had a different path.

By inspecting the library's installed files, the correct path was found to be `TikTokLive.client.errors`.

This commit corrects the import statement in `cogs/tiktok_cog.py` to use the correct path. This should resolve the final issue preventing the cog from loading. The diagnostic channel has been left in place for one final verification.