### PR TITLE
Fix(cogs): Correct all TikTokLive import paths

### DIFF
--- a/cogs/tiktok_cog.py
+++ b/cogs/tiktok_cog.py
@@ -6,7 +6,7 @@ from discord import app_commands
 from typing import Optional, Dict, Any
 from TikTokLive import TikTokLiveClient
 from TikTokLive.events import CommentEvent, ConnectEvent, DisconnectEvent, GiftEvent, LikeEvent, ShareEvent
-from TikTokLive.client.errors import UserNotFoundError, LiveNotFoundError
+from TikTokLive.client.errors import UserNotFoundError, UserOfflineError
 
 # --- Constants ---
 # Map gift coin values to the queue they unlock.
@@ -117,7 +117,7 @@ class TikTokCog(commands.GroupCog, name="tiktok", description="Commands for mana
         except UserNotFoundError:
             await edit_status("❌ Connection Failed", f"**Reason:** TikTok user `@{unique_id}` was not found.", discord.Color.red())
             await self._cleanup_connection()
-        except LiveNotFoundError:
+        except UserOfflineError:
             await edit_status("❌ Connection Failed", f"**Reason:** User `@{unique_id}` is not currently LIVE.", discord.Color.red())
             await self._cleanup_connection()
         except Exception as e:


### PR DESCRIPTION
The cog was still failing to load due to an `ImportError` because `LiveNotFoundError` was not in `TikTokLive.client.errors`.

This commit corrects the import statements in `cogs/tiktok_cog.py` to use the correct exception class, `UserOfflineError`, which is available in the library.

This should resolve the final issue preventing the cog from loading. The diagnostic channel has been left in place for one final verification.