### PR TITLE
Fix(cogs): Make the disconnect command non-blocking

### DIFF
--- a/cogs/tiktok_cog.py
+++ b/cogs/tiktok_cog.py
@@ -131,9 +131,11 @@ class TikTokCog(commands.GroupCog, name="tiktok", description="Commands for mana
             await interaction.response.send_message("Not currently connected to any stream.", ephemeral=True)
             return
 
-        await interaction.response.defer(ephemeral=True)
-        await self._cleanup_connection()
-        await interaction.followup.send("🔌 Successfully disconnected from the TikTok LIVE stream.", ephemeral=True)
+        # Respond immediately to the user
+        await interaction.response.send_message("🔌 Disconnecting... The bot will disconnect in the background.", ephemeral=True)
+
+        # Run the cleanup in a background task so it doesn't block
+        asyncio.create_task(self._cleanup_connection())
 
     async def _cleanup_connection(self):
         if self.bot.tiktok_client:


### PR DESCRIPTION
The `/tiktok disconnect` command was hanging because it was waiting for the entire `_cleanup_connection()` process to complete before responding to the interaction. This could cause the interaction to time out.

This commit changes the behavior to immediately respond to the user that the disconnection is in progress and then creates a background task using `asyncio.create_task()` to run the `_cleanup_connection()` method.

This provides a much better user experience by preventing the command from hanging.