### PR TITLE
feat: Implement file posting and debug channel

### DIFF
--- a/bot.log
+++ b/bot.log
@@ -3,3 +3,4 @@
 2025-10-01 01:43:09,084:INFO:root: You can get a bot token from https://discord.com/developers/applications
 2025-10-08 03:55:27,346:CRITICAL:root: DISCORD_BOT_TOKEN environment variable not found!
 2025-10-08 04:15:45,943:CRITICAL:root: DISCORD_BOT_TOKEN environment variable not found!
+2025-10-08 04:30:56,317:CRITICAL:root: DISCORD_BOT_TOKEN environment variable not found!

--- a/s3_utils.py
+++ b/s3_utils.py
@@ -110,3 +110,20 @@ class S3Client:
             except Exception as e:
                 logging.error(f"S3_CLIENT: Failed to upload bytes to {object_name}: {e}", exc_info=True)
                 return False
+
+    async def download_file_as_bytes(self, object_name: str) -> Optional[bytes]:
+        """
+        Downloads a file from the S3 bucket and returns it as a bytes object.
+
+        :param object_name: The key (path/filename) for the object in the bucket.
+        :return: The file content as bytes, or None if an error occurs.
+        """
+        async with self.session.client("s3", endpoint_url=self.endpoint_url) as s3_client:
+            try:
+                response = await s3_client.get_object(Bucket=self.bucket_name, Key=object_name)
+                file_bytes = await response['Body'].read()
+                logging.info(f"S3_CLIENT: Successfully downloaded {object_name}.")
+                return file_bytes
+            except Exception as e:
+                logging.error(f"S3_CLIENT: Failed to download file {object_name}: {e}", exc_info=True)
+                return None


### PR DESCRIPTION
This commit introduces two major improvements:
1.  **File Posting:** The `/next` command now downloads files from S3 and posts them directly as attachments in the 'Now Playing' channel, instead of just posting a link.
2.  **Debug Channel:** A new `DebugCog` provides admin commands (`/setdebugchannel`, `/cleandebugchannel`) to manage a dedicated channel for bot error logs. The global error handlers now post detailed tracebacks to this channel.

Fixes:
- The S3 client in `s3_utils.py` now automatically prepends `https://` to the endpoint URL, fixing the 'Invalid endpoint' error.
- The bot no longer crashes if S3 environment variables are not set; instead, file submissions are gracefully disabled.