### PR TITLE
feat: Add re-submission feature and fix rate-limiting

### DIFF
--- a/bot.log
+++ b/bot.log
@@ -5,3 +5,4 @@
 2025-10-08 04:15:45,943:CRITICAL:root: DISCORD_BOT_TOKEN environment variable not found!
 2025-10-08 04:30:56,317:CRITICAL:root: DISCORD_BOT_TOKEN environment variable not found!
 2025-10-08 04:53:39,117:CRITICAL:root: DISCORD_BOT_TOKEN environment variable not found!
+2025-10-08 05:03:05,756:CRITICAL:root: DISCORD_BOT_TOKEN environment variable not found!

--- a/cogs/admin_cog.py
+++ b/cogs/admin_cog.py
@@ -107,15 +107,9 @@ class AdminCog(commands.Cog):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         try:
-            # Step 1: Call the database function
-            await interaction.followup.send(f"⚙️ Accessing the database to set **{line}**...", ephemeral=True)
             await self.bot.db.set_channel_for_line(line, channel.id)
-
-            # Step 2: Update the queue display
-            await interaction.followup.send("🔄 Updating the queue display...", ephemeral=True)
             await self._update_queues(line)
             
-            # Step 3: Final confirmation
             embed = discord.Embed(
                 title="✅ Line Channel Set Successfully",
                 description=f"The **{line}** line has been set to {channel.mention}.",
@@ -372,15 +366,9 @@ class AdminCog(commands.Cog):
         await interaction.response.defer(ephemeral=True, thinking=True)
 
         try:
-            # Step 1: Call the database function
-            await interaction.followup.send("⚙️ Accessing the database...", ephemeral=True)
             await self.bot.db.set_bookmark_channel(channel.id)
-
-            # Step 2: Update the local cache
-            await interaction.followup.send("📝 Updating live settings cache...", ephemeral=True)
             self.bot.settings_cache['bookmark_channel_id'] = channel.id
 
-            # Step 3: Final confirmation
             embed = discord.Embed(
                 title="✅ Bookmark Channel Set Successfully",
                 description=f"The bookmark channel has been set to {channel.mention}.",

--- a/cogs/submission_cog.py
+++ b/cogs/submission_cog.py
@@ -401,19 +401,36 @@ class SubmissionCog(commands.Cog):
     @app_commands.command(name="setupsubmissionbuttons", description="[ADMIN] Setup submission buttons in current channel")
     @is_admin()
     async def setup_submission_buttons(self, interaction: discord.Interaction):
-        embed = discord.Embed(title="🎵 Music Submission Portal", description="Please follow the instructions for the submission type you are using.", color=discord.Color.blue())
+        """Sets up the submission buttons in the current channel."""
+        await interaction.response.defer(ephemeral=True)
+
+        embed = discord.Embed(
+            title="🎵 Music Submission Portal",
+            description="Please follow the instructions for the submission type you are using.",
+            color=discord.Color.blue()
+        )
         link_instructions = "1. Click 'Submit Link'.\n2. Fill out the form.\n3. Await confirmation."
         file_instructions = "1. Use the `/submitfile` command.\n2. Attach your audio file.\n3. Fill in the options."
+        resubmit_instructions = "1. Click 'Re-submit From History'.\n2. Choose a song from the dropdown.\n3. Await confirmation."
         embed.add_field(name="🔗 Link Submissions", value=link_instructions, inline=False)
         embed.add_field(name="📁 File Submissions", value=file_instructions, inline=False)
+        embed.add_field(name="🔁 Re-submissions", value=resubmit_instructions, inline=False)
+
         view = SubmissionButtonView(self.bot)
-        await interaction.response.send_message(embed=embed, view=view)
-        message = await interaction.original_response()
+
         try:
-            await message.pin()
-            await interaction.followup.send("✅ Submission buttons have been set up and pinned!", ephemeral=True)
-        except discord.Forbidden:
-            await interaction.followup.send("✅ Buttons set up, but I couldn't pin the message.", ephemeral=True)
+            # Send the message to the channel directly
+            message = await interaction.channel.send(embed=embed, view=view)
+
+            # Try to pin the message
+            try:
+                await message.pin()
+                await interaction.followup.send("✅ Submission buttons have been set up and pinned!", ephemeral=True)
+            except discord.Forbidden:
+                await interaction.followup.send("✅ Buttons set up, but I couldn't pin the message. Please check my permissions.", ephemeral=True)
+
+        except Exception as e:
+            await interaction.followup.send(f"❌ An error occurred while setting up buttons: {e}", ephemeral=True)
 
 async def setup(bot):
     await bot.add_cog(SubmissionCog(bot))


### PR DESCRIPTION
This commit introduces a new feature allowing users to re-submit songs from their history and fixes critical rate-limiting issues.

Features:
- **Re-submission from History:** A new "Re-submit From History" button has been added to the submission portal. This allows users to select one of their past 25 submissions from a dropdown menu and re-submit it to the 'Free' queue.

Fixes:
- **Rate-Limiting:** The `/setline`, `/setbookmarkchannel`, and `/setupsubmissionbuttons` commands have been refactored to reduce the number of API calls they make, preventing the bot from being rate-limited by Discord. This was achieved by removing intermediate feedback messages and sending a single confirmation at the end of the command's execution.
- **File Attachment Logic:** The `/next` command now correctly downloads files from S3 and posts them as attachments in the 'Now Playing' channel.
- **S3 Endpoint and Stability:** Includes previous fixes for the S3 client to handle missing credentials gracefully and to automatically correct the endpoint URL.