### PR TITLE
feat: Add live queue command and adjust gift rewards

### DIFF
--- a/cogs/live_queue_cog.py
+++ b/cogs/live_queue_cog.py
@@ -49,6 +49,14 @@ class LiveQueueCog(commands.Cog):
         embed = discord.Embed(title="✅ Live Queue Channel Set", description=f"The public live queue display will now be managed in {channel.mention}.", color=discord.Color.green())
         await interaction.followup.send(embed=embed, ephemeral=True)
 
+    @app_commands.command(name="setup-live-queue", description="[ADMIN] Set the channel for the public live queue display.")
+    @app_commands.describe(channel="The text channel to use for the live queue.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def setup_live_queue(self, interaction: discord.Interaction, channel: discord.TextChannel):
+        """(Alias for /setqueuechannel) Sets the channel for the live queue."""
+        # This command just calls the other command's logic
+        await self.set_queue_channel(interaction, channel)
+
     @tasks.loop(seconds=20)
     async def update_live_queue(self):
         """Periodically fetches the queue and updates the live queue message."""

--- a/cogs/tiktok_cog.py
+++ b/cogs/tiktok_cog.py
@@ -218,7 +218,12 @@ class TikTokCog(commands.GroupCog, name="tiktok", description="Commands for mana
         if event.gift.streakable and event.streaking: return
 
         # Award points for all gifts
-        points = event.gift.diamond_count
+        # Updated point logic: 2 points per coin for gifts under 1000, otherwise 1 point per coin
+        if event.gift.diamond_count < 1000:
+            points = event.gift.diamond_count * 2
+        else:
+            points = event.gift.diamond_count
+
         await self._handle_interaction(event, 'gift', points, value=event.gift.name, coin_value=event.gift.diamond_count)
 
         # Tiered skip logic


### PR DESCRIPTION
- Adds the `/setup-live-queue` command as an alias for `/setqueuechannel` in `cogs/live_queue_cog.py` to improve administrator experience and command discoverability.
- Updates the point calculation in `cogs/tiktok_cog.py` to award 2 points per coin for TikTok gifts valued under 1000 coins, rewarding smaller contributions more effectively.