### PR TITLE
fix: Add detailed diagnostic logging for command registration

### DIFF
--- a/cogs/live_queue_cog.py
+++ b/cogs/live_queue_cog.py
@@ -2,6 +2,7 @@
 Live Queue Cog - Manages the public-facing #live-queue channel display.
 """
 
+import asyncio
 import discord
 from discord.ext import commands, tasks
 from discord import app_commands
@@ -15,14 +16,20 @@ class LiveQueueCog(commands.Cog):
         self.bot = bot
         self.live_queue_channel_id: Optional[int] = None
         self.live_queue_message_id: Optional[int] = None
+        # Use asyncio.create_task to avoid awaiting here
+        asyncio.create_task(self.bot._send_trace("LiveQueueCog initialized."))
         self.update_live_queue.start()
 
     async def cog_load(self):
         """Load initial settings on cog load."""
+        await self.bot._send_trace("LiveQueueCog cog_load started.")
         config = await self.bot.db.get_bot_config('live_queue')
         if config:
             self.live_queue_channel_id = config.get('channel_id')
             self.live_queue_message_id = config.get('message_id')
+            await self.bot._send_trace(f"LiveQueueCog loaded config: channel_id={self.live_queue_channel_id}, message_id={self.live_queue_message_id}")
+        else:
+            await self.bot._send_trace("LiveQueueCog found no initial config.")
 
     def cog_unload(self):
         """Cancel tasks when the cog is unloaded."""

--- a/main.py
+++ b/main.py
@@ -83,14 +83,23 @@ class MusicQueueBot(commands.Bot):
         await self._send_trace("Syncing slash commands...")
         try:
             guild_id = os.getenv('GUILD_ID')
+            synced_commands = []
             if guild_id:
                 guild = discord.Object(id=int(guild_id))
                 self.tree.copy_global_to(guild=guild)
                 synced = await self.tree.sync(guild=guild)
+                synced_commands = [c.name for c in synced]
                 await self._send_trace(f"Synced {len(synced)} command(s) to guild {guild_id}.")
             else:
                 synced = await self.tree.sync()
+                synced_commands = [c.name for c in synced]
                 await self._send_trace(f"Synced {len(synced)} command(s) globally.")
+
+            if synced_commands:
+                await self._send_trace(f"Registered commands: {', '.join(synced_commands)}")
+            else:
+                await self._send_trace("No commands were synced.")
+
         except Exception as e:
             await self._send_trace(f"Failed to sync commands: {e}", is_error=True)
         await self._send_trace("Finished syncing commands.")


### PR DESCRIPTION
This commit introduces comprehensive logging to help diagnose issues with slash command registration and cog loading.

- In `main.py`, the `setup_hook` now logs a complete list of all slash command names that are successfully synced with Discord. This will provide a definitive record of which commands the bot has registered.
- In `cogs/live_queue_cog.py`, trace logging has been added to the `__init__` and `cog_load` methods to confirm that the cog is being initialized and loaded correctly.
- These logs are sent to the `bot-debug` channel, providing a centralized location for diagnostics.