### PR TITLE
feat: Implement user submission history and multiple enhancements

### DIFF
--- a/database.py
+++ b/database.py
@@ -465,6 +465,17 @@ class Database:
                 return original_line
             return None
 
+    async def delete_submission_from_history(self, public_id: str, user_id: int) -> bool:
+        """
+        Permanently deletes a submission from the history.
+        Only allows a user to delete their own submission.
+        """
+        query = "DELETE FROM submissions WHERE public_id = $1 AND user_id = $2"
+        async with self.pool.acquire() as conn:
+            result = await conn.execute(query, public_id, user_id)
+            # "DELETE 1" means one row was deleted.
+            return result == "DELETE 1"
+
     async def get_user_lifetime_stats(self, user_id: int) -> Dict[str, int]:
         """
         Calculates lifetime interaction stats (likes, comments, shares, gift coins)


### PR DESCRIPTION
This is a comprehensive update that introduces several major features and quality-of-life improvements based on user feedback.

- **User Submission Management (`/my-submissions`):**
  - A new `/my-submissions` command allows users to view their submission history in a paginated, interactive embed.
  - Users can now remove their own songs from any active queue.
  - Users can now permanently delete a song from their submission history, with a confirmation step to prevent accidents.

- **`/next` Command Enhancement:**
  - The ephemeral admin message for the `/next` command now includes the submitter's TikTok handle, providing more context during review.

- **Public Queue Enhancement:**
  - The public-facing live queue now displays the submitter's Discord name next to each song, making the queue more informative for the audience.

- **Settings Command (`/show-settings`):**
  - A new `/show-settings` admin command displays the status of all configured channels.
  - It includes a "Prune Missing Channels" button to automatically clean up settings for channels that no longer exist.