### PR TITLE
feat: Implement persistent, paginated reviewer queues

### DIFF
--- a/cogs/reviewer_queue_cog.py
+++ b/cogs/reviewer_queue_cog.py
@@ -4,11 +4,170 @@ Handles the display of a detailed, persistent queue for staff review.
 """
 import discord
 from discord import app_commands
-from discord.ext import commands, tasks
+from discord.ext import commands
 import logging
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 
 from database import Database, QueueLine
+
+ITEMS_PER_PAGE = 10
+
+class ReviewerView(discord.ui.View):
+    """A persistent, paginated view for the main reviewer queue."""
+    def __init__(self, db: Database):
+        super().__init__(timeout=None)
+        self.db = db
+        self.current_page = 0
+
+    async def generate_embed(self) -> discord.Embed:
+        """Generates the embed for the current page."""
+        submissions = await self.db.get_all_active_queue_songs(detailed=True)
+
+        if not submissions:
+            self.cleanup_buttons()
+            return discord.Embed(title="Reviewer Queue", description="The queue is currently empty.", color=discord.Color.blue())
+
+        total_pages = (len(submissions) - 1) // ITEMS_PER_PAGE
+        self.current_page = max(0, min(self.current_page, total_pages))
+
+        start_index = self.current_page * ITEMS_PER_PAGE
+        end_index = start_index + ITEMS_PER_PAGE
+        page_submissions = submissions[start_index:end_index]
+
+        embed = discord.Embed(title=f"Live Reviewer Queue (Page {self.current_page + 1}/{total_pages + 1})", color=discord.Color.dark_purple())
+        description = ""
+        for sub in page_submissions:
+            stats = await self.db.get_user_lifetime_stats(sub['user_id'])
+            stats_line = f"👍{stats['like']} 💬{stats['comment']} 🔗{stats['share']} 🪙{stats['gift_coins']}"
+            entry = (
+                f"**#{sub['public_id']} | {sub['artist_name']} - {sub['song_name']}**\n"
+                f"> **Submitter:** {sub['username']} (`{sub['user_id']}`)\n"
+                f"> **Queue:** `{sub['queue_line']}` | **Score:** `{sub.get('total_score', 0)}`\n"
+            )
+            if sub.get('tiktok_username'):
+                entry += f"> **TikTok:** `{sub['tiktok_username']}`\n"
+            entry += f"> **Lifetime Stats:** {stats_line}\n"
+            if sub['link_or_file'].startswith("http"):
+                entry += f"> **Link:** [Click Here]({sub['link_or_file']})\n"
+            if sub.get('note'):
+                entry += f"> **Note:** *{sub['note']}*\n"
+            entry += "---\n"
+            description += entry
+
+        embed.description = description
+        embed.set_footer(text="Use the buttons to navigate or refresh.")
+        embed.timestamp = discord.utils.utcnow()
+
+        self.update_button_states(total_pages)
+        return embed
+
+    def cleanup_buttons(self):
+        """Disables all buttons."""
+        for item in self.children:
+            if isinstance(item, discord.ui.Button):
+                item.disabled = True
+
+    def update_button_states(self, total_pages: int):
+        """Enables/disables buttons based on the current page."""
+        self.prev_page.disabled = self.current_page <= 0
+        self.next_page.disabled = self.current_page >= total_pages
+
+    async def update_message(self, interaction: discord.Interaction):
+        """Updates the message with the new embed and view state."""
+        embed = await self.generate_embed()
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="< Prev", style=discord.ButtonStyle.primary, custom_id="rq_prev_page")
+    async def prev_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.current_page -= 1
+        await self.update_message(interaction)
+
+    @discord.ui.button(label="Refresh", style=discord.ButtonStyle.success, custom_id="rq_refresh")
+    async def refresh(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.update_message(interaction)
+
+    @discord.ui.button(label="Next >", style=discord.ButtonStyle.primary, custom_id="rq_next_page")
+    async def next_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.current_page += 1
+        await self.update_message(interaction)
+
+class PendingSkipsView(discord.ui.View):
+    """A persistent, paginated view for the pending skips queue."""
+    def __init__(self, db: Database):
+        super().__init__(timeout=None)
+        self.db = db
+        self.current_page = 0
+
+    async def generate_embed(self) -> discord.Embed:
+        """Generates the embed for the current page."""
+        submissions = await self.db.get_queue_submissions(QueueLine.PENDING_SKIPS.value)
+
+        if not submissions:
+            self.cleanup_buttons()
+            return discord.Embed(title="Pending Skips Queue", description="The queue is currently empty.", color=discord.Color.blue())
+
+        total_pages = (len(submissions) - 1) // ITEMS_PER_PAGE
+        self.current_page = max(0, min(self.current_page, total_pages))
+
+        start_index = self.current_page * ITEMS_PER_PAGE
+        end_index = start_index + ITEMS_PER_PAGE
+        page_submissions = submissions[start_index:end_index]
+
+        embed = discord.Embed(title=f"Pending Skips Queue (Page {self.current_page + 1}/{total_pages + 1})", color=discord.Color.orange())
+        description = ""
+        for sub in page_submissions:
+            stats = await self.db.get_user_lifetime_stats(sub['user_id'])
+            stats_line = f"👍{stats['like']} 💬{stats['comment']} 🔗{stats['share']} 🪙{stats['gift_coins']}"
+            entry = (
+                f"**#{sub['public_id']} | {sub['artist_name']} - {sub['song_name']}**\n"
+                f"> **Submitter:** {sub['username']} (`{sub['user_id']}`)\n"
+            )
+            if sub.get('tiktok_username'):
+                entry += f"> **TikTok:** `{sub['tiktok_username']}`\n"
+            entry += f"> **Lifetime Stats:** {stats_line}\n"
+            if sub['link_or_file'].startswith("http"):
+                entry += f"> **Link:** [Click Here]({sub['link_or_file']})\n"
+            if sub.get('note'):
+                entry += f"> **Note:** *{sub['note']}*\n"
+            entry += "---\n"
+            description += entry
+
+        embed.description = description
+        embed.set_footer(text="Use the buttons to navigate or refresh.")
+        embed.timestamp = discord.utils.utcnow()
+
+        self.update_button_states(total_pages)
+        return embed
+
+    def cleanup_buttons(self):
+        """Disables all buttons."""
+        for item in self.children:
+            if isinstance(item, discord.ui.Button):
+                item.disabled = True
+
+    def update_button_states(self, total_pages: int):
+        """Enables/disables buttons based on the current page."""
+        self.prev_page.disabled = self.current_page <= 0
+        self.next_page.disabled = self.current_page >= total_pages
+
+    async def update_message(self, interaction: discord.Interaction):
+        """Updates the message with the new embed and view state."""
+        embed = await self.generate_embed()
+        await interaction.response.edit_message(embed=embed, view=self)
+
+    @discord.ui.button(label="< Prev", style=discord.ButtonStyle.primary, custom_id="psq_prev_page")
+    async def prev_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.current_page -= 1
+        await self.update_message(interaction)
+
+    @discord.ui.button(label="Refresh", style=discord.ButtonStyle.success, custom_id="psq_refresh")
+    async def refresh(self, interaction: discord.Interaction, button: discord.ui.Button):
+        await self.update_message(interaction)
+
+    @discord.ui.button(label="Next >", style=discord.ButtonStyle.primary, custom_id="psq_next_page")
+    async def next_page(self, interaction: discord.Interaction, button: discord.ui.Button):
+        self.current_page += 1
+        await self.update_message(interaction)
 
 class ReviewerQueueCog(commands.Cog):
     """A cog for managing the detailed reviewer queue display."""
@@ -16,124 +175,53 @@ class ReviewerQueueCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.db: Database = bot.db
-        self.reviewer_queue_task.start()
-        self.last_message_content = ""
+        # Register the persistent views
+        bot.add_view(ReviewerView(bot.db))
+        bot.add_view(PendingSkipsView(bot.db))
 
     def cog_unload(self):
-        self.reviewer_queue_task.cancel()
+        # No tasks to cancel anymore
+        pass
 
     @app_commands.command(name="setreviewerchannel", description="[ADMIN] Sets the channel for the detailed reviewer queue.")
     @app_commands.checks.has_permissions(administrator=True)
     async def set_reviewer_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
         """Sets the channel for the reviewer queue message."""
+        # Purge old bot messages in the channel
+        await channel.purge(limit=10, check=lambda m: m.author == self.bot.user)
+
+        view = ReviewerView(self.db)
+        embed = await view.generate_embed()
+
+        message = await channel.send(embed=embed, view=view)
+
         await self.db.set_bot_config('reviewer_queue_channel_id', channel_id=channel.id)
-        await self.db.set_bot_config('reviewer_queue_message_id', message_id=None)
+        await self.db.set_bot_config('reviewer_queue_message_id', message_id=message.id)
         self.bot.settings_cache['reviewer_queue_channel_id'] = channel.id
-        self.bot.settings_cache['reviewer_queue_message_id'] = None
-        embed = discord.Embed(title="✅ Reviewer Queue Channel Set", description=f"The detailed reviewer queue will now be displayed in {channel.mention}.", color=discord.Color.green())
-        await interaction.response.send_message(embed=embed, ephemeral=True)
+        self.bot.settings_cache['reviewer_queue_message_id'] = message.id
 
-    async def _generate_reviewer_embeds(self) -> List[discord.Embed]:
-        """Generates a list of embeds for the detailed reviewer queue."""
-        submissions = await self.db.get_all_active_queue_songs(detailed=True)
+        response_embed = discord.Embed(title="✅ Reviewer Queue Channel Set", description=f"The reviewer queue has been set up in {channel.mention}.", color=discord.Color.green())
+        await interaction.response.send_message(embed=response_embed, ephemeral=True)
 
-        if not submissions:
-            return [discord.Embed(title="Reviewer Queue", description="The queue is currently empty.", color=discord.Color.blue())]
+    @app_commands.command(name="setpendingskipschannel", description="[ADMIN] Sets the channel for the pending skips queue.")
+    @app_commands.checks.has_permissions(administrator=True)
+    async def set_pending_skips_channel(self, interaction: discord.Interaction, channel: discord.TextChannel):
+        """Sets the channel for the pending skips queue message."""
+        # Purge old bot messages in the channel
+        await channel.purge(limit=10, check=lambda m: m.author == self.bot.user)
 
-        embeds = []
-        current_embed = discord.Embed(title="Live Reviewer Queue", color=discord.Color.dark_purple())
-        current_description = ""
+        view = PendingSkipsView(self.db)
+        embed = await view.generate_embed()
 
-        for sub in submissions:
-            # Get user's lifetime interaction stats
-            stats = await self.db.get_user_lifetime_stats(sub['user_id'])
-            stats_line = f"👍{stats['like']} 💬{stats['comment']} 🔗{stats['share']} 🪙{stats['gift_coins']}"
+        message = await channel.send(embed=embed, view=view)
 
-            # Format the entry with all the details
-            entry = (
-                f"**#{sub['public_id']} | {sub['artist_name']} - {sub['song_name']}**\n"
-                f"> **Submitter:** {sub['username']} (`{sub['user_id']}`)\n"
-                f"> **Queue:** `{sub['queue_line']}` | **Score:** `{sub.get('total_score', 0)}`\n"
-            )
-            # Display TikTok handle if it was linked at the time of submission
-            if sub.get('tiktok_username'):
-                entry += f"> **TikTok:** `{sub['tiktok_username']}`\n"
+        await self.db.set_bot_config('pending_skips_channel_id', channel_id=channel.id)
+        await self.db.set_bot_config('pending_skips_message_id', message_id=message.id)
+        self.bot.settings_cache['pending_skips_channel_id'] = channel.id
+        self.bot.settings_cache['pending_skips_message_id'] = message.id
 
-            entry += f"> **Lifetime Stats:** {stats_line}\n"
-
-            if sub['link_or_file'].startswith("http"):
-                entry += f"> **Link:** [Click Here]({sub['link_or_file']})\n"
-            if sub.get('note'):
-                entry += f"> **Note:** *{sub['note']}*\n"
-            entry += "---\n"
-
-            # Discord embed description limit is 4096 characters. We'll be safe.
-            if len(current_description) + len(entry) > 4000:
-                current_embed.description = current_description
-                embeds.append(current_embed)
-                current_embed = discord.Embed(title="Live Reviewer Queue (Cont.)", color=discord.Color.dark_purple())
-                current_description = ""
-
-            current_description += entry
-
-        current_embed.description = current_description
-        current_embed.set_footer(text="This is a detailed view for reviewers.")
-        current_embed.timestamp = discord.utils.utcnow()
-        embeds.append(current_embed)
-
-        return embeds
-
-    @tasks.loop(seconds=15)
-    async def reviewer_queue_task(self):
-        """The main background task to update the reviewer queue message."""
-        channel_id = self.bot.settings_cache.get('reviewer_queue_channel_id')
-        if not channel_id:
-            return
-
-        channel = self.bot.get_channel(int(channel_id))
-        if not channel:
-            logging.warning(f"Reviewer queue channel with ID {channel_id} not found.")
-            return
-
-        try:
-            new_embeds = await self._generate_reviewer_embeds()
-            new_content = "".join([str(e.to_dict()) for e in new_embeds])
-
-            if new_content == self.last_message_content:
-                return
-
-            message_id = self.bot.settings_cache.get('reviewer_queue_message_id')
-            message: Optional[discord.Message] = None
-
-            if message_id:
-                try:
-                    message = await channel.fetch_message(int(message_id))
-                    # Ensure the message is still pinned
-                    if not message.pinned:
-                        await message.pin(reason="Re-pinning reviewer queue message.")
-                except discord.NotFound:
-                    message = None # Message was deleted, create a new one
-
-            if message:
-                await message.edit(embeds=new_embeds)
-            else:
-                # Purge old pinned messages from the bot before creating a new one.
-                await channel.purge(limit=10, check=lambda m: m.author == self.bot.user and m.pinned)
-                message = await channel.send(embeds=new_embeds)
-                await message.pin()
-                await self.db.set_bot_config('reviewer_queue_message_id', message_id=message.id)
-                self.bot.settings_cache['reviewer_queue_message_id'] = message.id
-
-            self.last_message_content = new_content
-
-        except discord.errors.Forbidden:
-            logging.error(f"Missing permissions to manage reviewer queue in channel {channel_id}.")
-        except Exception as e:
-            logging.error(f"An error occurred in the reviewer queue task: {e}", exc_info=True)
-
-    @reviewer_queue_task.before_loop
-    async def before_reviewer_queue_task(self):
-        await self.bot.wait_until_ready()
+        response_embed = discord.Embed(title="✅ Pending Skips Channel Set", description=f"The pending skips queue has been set up in {channel.mention}.", color=discord.Color.green())
+        await interaction.response.send_message(embed=response_embed, ephemeral=True)
 
 async def setup(bot: commands.Bot):
     await bot.add_cog(ReviewerQueueCog(bot))


### PR DESCRIPTION
This commit introduces a major refactor of the reviewer and pending skips queues.

- Replaces the auto-updating background tasks with persistent, paginated `discord.ui.View` classes for both the main reviewer queue and the pending skips queue. This provides a more stable and user-friendly experience with navigation and refresh buttons.
- Adds `/setreviewerchannel` and `/setpendingskipschannel` commands to create these persistent views in designated channels.
- Fixes a `NOT NULL` constraint violation that occurred when removing submissions from the queue. Submissions are now moved to a 'Removed' state instead of having their `queue_line` set to `NULL`.